### PR TITLE
Revert "Add instructions and config file to setup as a Linux service"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,5 @@ cargo build --release
 ## Run
 
 ```console
-cargo run  # or ./target/release/helloworld
-```
-
-## Setup as a `Supervisor` service
-
-Copy the binary `target/release/helloworld` to the remote machine folder according to [cosmian_helloworld.ini](./resources/supervisor/cosmian_helloworld.ini) statement (ie: `/usr/sbin/cosmian_helloworld`).
-
-Copy the [cosmian_helloworld.ini](./resources/supervisor/cosmian_helloworld.ini) config file as `/etc/supervisord.d/cosmian_helloworld.ini` in the remote machine.
-
-Run:
-
-```console
-supervisorctl reload
-supervisorctl start cosmian_helloworld
-supervisorctl status cosmian_helloworld
+cargo run  # or ./target/release/hellworld
 ```

--- a/resources/supervisor/cosmian_helloworld.ini
+++ b/resources/supervisor/cosmian_helloworld.ini
@@ -1,8 +1,0 @@
-[program:cosmian_helloworld]
-command=cosmian_helloworld
-directory=/usr/sbin
-autostart=false
-autorestart=true
-user=root
-stderr_logfile=/var/log/cosmian_helloworld.err.log
-stdout_logfile=/var/log/cosmian_helloworld.out.log


### PR DESCRIPTION
Reverts Cosmian/helloworld-service#1 because  `supervisor`  is not used anymore.